### PR TITLE
split build into 2 Dockerfiles

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+*.md
+*.doc
+/target/*
+*/target/*
+*.iml
+*.ipr
+*.iws
+*.log
+/.idea/
+*/test-output/*
+Dockerfile*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,6 @@
 FROM jetty:9.3.0-jre8
 
-COPY ./target/*.war $JETTY_HOME/webapps/
+# DB is created under home directory of user jetty that must be created
+RUN mkdir -p /home/jetty && chown jetty:jetty /home/jetty
+
+COPY ./target/*.war $JETTY_BASE/webapps/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,3 @@
-FROM gaiaadm/basejava:0.1.0
+FROM jetty:9.3.0-jre8
 
-ENV GAIA_HOME=/usr/local/gaia
-RUN mkdir -p  $GAIA_HOME
-
-ADD . $GAIA_HOME
-WORKDIR $GAIA_HOME
-
-RUN mvn clean install
-RUN cp $GAIA_HOME/target/*.war $JETTY_HOME/webapps
-
-WORKDIR $JETTY_HOME
-EXPOSE 8080
-
-# CMD ["/bin/bash"]
-CMD java -jar start.jar
+COPY ./target/*.war $JETTY_HOME/webapps/

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,1 +1,9 @@
-FROM maven:3.3.3-jdk-8-onbuild
+FROM maven:3.3.3-jdk-8
+
+RUN mkdir -p /usr/local/gaia
+WORKDIR /usr/local/gaia
+
+ADD . /usr/local/gaia
+
+# RUN ["mvn","-DuseProxy=true","-DproxyHost=web-proxy.israel.hp.com","-DproxyPort=8080","clean","install"]
+RUN ["mvn","clean","install"]

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,9 +1,11 @@
 FROM maven:3.3.3-jdk-8
 
-RUN mkdir -p /usr/local/gaia
-WORKDIR /usr/local/gaia
+ENV GAIA_HOME=/usr/local/gaia
 
-ADD . /usr/local/gaia
+RUN mkdir -p $GAIA_HOME
+WORKDIR $GAIA_HOME
+
+ADD . $GAIA_HOME
 
 # RUN ["mvn","-DuseProxy=true","-DproxyHost=web-proxy.israel.hp.com","-DproxyPort=8080","clean","install"]
 RUN ["mvn","clean","install"]

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,0 +1,1 @@
+FROM maven:3.3.3-jdk-8-onbuild

--- a/README.md
+++ b/README.md
@@ -16,8 +16,12 @@ Current limitations/not implemented yet:
 - Logging
 
 Manually run with docker:
-- Build the image (it includes building the project also): docker build -t gaiaadm/sts:0.1.0 .
-- Run the container: docker run -d -p 9001:8080 gaiaadm/sts:0.1.0
+- Build the `sts.war` with following command: `docker build -t sts-build -f Dockerfile.build .`
+- Copy created `sts.war` to your host `target` folder
+  - create container: `docker create --name build-cont sts-build`
+  - copy `sts.war`: `docker cp build-cont:/usr/src/app/target/sts.war ./target/`
+- Build STS image with: `docker build -t gaiaadm:sts .`
+- Create and run STS container: `docker run -d -p 9001:8080 gaiaadm/sts`
 - Quick check URL from outside of the container: curl -v http://localhost:9001/sts/oauth/check_token?token=62ad16cf-ab6c-42fa-af3d-359ecf98cdec
 
 
@@ -119,4 +123,3 @@ Other API's exposed:
 All APIs use application/json as Content-Type and Accept header values
 
 See more details about Oauth2 in Oauth2-authorization.docx
-

--- a/README.md
+++ b/README.md
@@ -1,49 +1,49 @@
-Authorization server based on spring security.
+## Authorization server based on spring security.
 - Supports Client Credentials flow of Oauth2 (https://tools.ietf.org/html/rfc6749#section-4.4)
 - Runs on any servlet container or with Jetty embedded (mvn jetty:run on port 9001)
 - Running with H2 DB embedded for persisting client configuration and access tokens.
   Schema name is auth_db under your user home folder. The schema is created upon creation of the 1st client
 - H2 DB accessible via the web console: http://localhost:9093/ (select H2 embedded, URL: jdbc:h2:~/sts_db)
 
-Notes:
+## Notes:
 - Token never expires (can be revoked)
 
-Current limitations/not implemented yet:
+## Current limitations/not implemented yet:
 - No deployment via fleetctl
 - Distinguish between tenants/schemas based on token (token enrichment?)
-- Client authentication when requesting token
-- Authentication when registering client
-- Logging
+- Client authentication is missing when requesting token or registering client
 
-Manually run with docker:
-- Build the `sts.war` with following command: `docker build -t sts-build -f Dockerfile.build .`
-- Copy created `sts.war` to your host `target` folder
-  - create container: `docker create --name build-cont sts-build`
-  - copy `sts.war`: `docker cp build-cont:/usr/src/app/target/sts.war ./target/`
-- Build STS image with: `docker build -t gaiaadm:sts .`
-- Create and run STS container: `docker run -d -p 9001:8080 gaiaadm/sts`
-- Quick check URL from outside of the container: `curl -v http://localhost:9001/sts/oauth/check_token?token=62ad16cf-ab6c-42fa-af3d-359ecf98cdec`
+## Manually run with docker (automated with buildAndRun.sh):
+- docker build -t sts_build -f Dockerfile.build .
+- Optional: docker rm build_cont
+- docker create --name build_cont sts_build
+- docker cp build_cont:/usr/local/gaia/target/sts.war ./target/
+- docker build -t gaiaadm/sts .
+- docker run -d -u jetty -p 9001:8080 gaiaadm/sts
+- Optional: check that server started as needed from outside of docker - curl -v http://localhost:9001/sts/oauth/check_token?token=62ad16cf-ab6c-42fa-af3d-359ecf98cdec
+### Base images used during the process:
+- maven:3.3.3-jdk-8 - build the project (https://registry.hub.docker.com/u/library/maven/)
+- jetty:9.3.0-jre8 - run the server (https://registry.hub.docker.com/u/library/jetty/)
 
-
-Flow:
+## Flow:
 - Create Client
     @POST to http://localhost:9001/sts/oauth/client
     Body example:
-    {
+    `{
         "client_id": "restapp",
         "client_secret": "secret",
         "scope": "trust",
         "authorized_grant_types": "client_credentials",
         "authorities": "ROLE_APP",
         "additional_information": "more data"
-    }
+    }`
 -  Obtain token
     @POST to http://localhost:9001/sts/oauth/token?grant_type=client_credentials&client_id=restapp&client_secret=secret
 
 
 - Use token in your client - on example of Java webapp. NOT FINAL VERSION - works but should be cleaned up.
-    web.xml:
-        <context-param>
+    **web.xml**:
+        `<context-param>
             <param-name>contextConfigLocation</param-name>
             <param-value>
                 /WEB-INF/spring-security.xml
@@ -78,11 +78,11 @@ Flow:
         <filter-mapping>
             <filter-name>springSecurityFilterChain</filter-name>
             <url-pattern>/*</url-pattern>
-        </filter-mapping>
+        </filter-mapping>`
 
-    spring-security.xml (${authServer} is in default.properties, can be reset via -D parameter):
+    **spring-security.xml** (${authServer} is in default.properties, can be reset via -D parameter):
 
-    <context:property-placeholder system-properties-mode="OVERRIDE" location="classpath*:default.properties"/>
+    `<context:property-placeholder system-properties-mode="OVERRIDE" location="classpath*:default.properties"/>
     <bean class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer">
         <property name="systemPropertiesMode" value="2" />
     </bean>
@@ -110,16 +110,15 @@ Flow:
         </constructor-arg>
     </bean>
 
-    <oauth:resource-server id="resourceServerFilter" resource-id="test" token-services-ref="remoteTokenServices"/>
+    <oauth:resource-server id="resourceServerFilter" resource-id="test" token-services-ref="remoteTokenServices"/>`
 
 
-Other API's exposed:
+## Other API's exposed:
 - Check token: @GET to http://localhost:9001/sts/oauth/check_token?token=<token>. This API is actually used by client
 - Revoke token: @DELETE to http://localhost:9001/sts/oauth/token/revoke?token=<token>
 - Get client details by id: @GET to http://localhost:9001/sts/oauth/client/<client_id>
 - Get all registered clients: @GET to http://localhost:9001/sts/oauth/client
 - Delete client: @DELETE to http://localhost:9001/sts/oauth/client/<client_id>
+*All APIs use application/json as Content-Type and Accept header values*
 
-All APIs use application/json as Content-Type and Accept header values
-
-See more details about Oauth2 in Oauth2-authorization.docx
+**See more details about Oauth2 in Oauth2-authorization.docx**

--- a/README.md
+++ b/README.md
@@ -20,16 +20,17 @@
 - docker cp build_cont:/usr/local/gaia/target/sts.war ./target/
 - docker build -t gaiaadm/sts .
 - docker run -d -u jetty -p 9001:8080 gaiaadm/sts
-- Optional: check that server started as needed from outside of docker - curl -v http://localhost:9001/sts/oauth/check_token?token=62ad16cf-ab6c-42fa-af3d-359ecf98cdec
-**Base images used during the process**:
+- Optional: check that server started as needed from outside of docker - curl -v http://localhost:9001/sts/oauth/check_token?token=62ad16cf-ab6c-42fa-af3d-359ecf98cdec <br />
+***Base images used during the process***:
 - maven:3.3.3-jdk-8 - build the project (https://registry.hub.docker.com/u/library/maven/)
-- jetty:9.3.0-jre8 - run the server (https://registry.hub.docker.com/u/library/jetty/)
-*The above process is automated with buildAndRun.sh script*
+- jetty:9.3.0-jre8 - run the server (https://registry.hub.docker.com/u/library/jetty/) <br />
+***The above process is automated with buildAndRun.sh script***
 
 ## Flow:
 - Create Client
     @POST to http://localhost:9001/sts/oauth/client
-    Body example:
+    Body example: <br />
+    ```
     {
         "client_id": "restapp",
         "client_secret": "secret",
@@ -38,6 +39,7 @@
         "authorities": "ROLE_APP",
         "additional_information": "more data"
     }
+    ```
 -  Obtain token
     @POST to http://localhost:9001/sts/oauth/token?grant_type=client_credentials&client_id=restapp&client_secret=secret
 
@@ -82,7 +84,7 @@
         </filter-mapping>
 
     **spring-security.xml** (${authServer} is in default.properties, can be reset via -D parameter):
-
+```
     <context:property-placeholder system-properties-mode="OVERRIDE" location="classpath*:default.properties"/>
     <bean class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer">
         <property name="systemPropertiesMode" value="2" />
@@ -112,14 +114,14 @@
     </bean>
 
     <oauth:resource-server id="resourceServerFilter" resource-id="test" token-services-ref="remoteTokenServices"/>
-
+```
 
 ## Other API's exposed:
 - Check token: @GET to http://localhost:9001/sts/oauth/check_token?token=<token>. This API is actually used by client
 - Revoke token: @DELETE to http://localhost:9001/sts/oauth/token/revoke?token=<token>
 - Get client details by id: @GET to http://localhost:9001/sts/oauth/client/<client_id>
 - Get all registered clients: @GET to http://localhost:9001/sts/oauth/client
-- Delete client: @DELETE to http://localhost:9001/sts/oauth/client/<client_id>
+- Delete client: @DELETE to http://localhost:9001/sts/oauth/client/<client_id> <br />
 *All APIs use application/json as Content-Type and Accept header values*
 
 **See more details about Oauth2 in Oauth2-authorization.docx**

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 - Distinguish between tenants/schemas based on token (token enrichment?)
 - Client authentication is missing when requesting token or registering client
 
-## Manually run with docker (automated with buildAndRun.sh):
+## Manually run with docker 
 - docker build -t sts_build -f Dockerfile.build .
 - Optional: docker rm build_cont
 - docker create --name build_cont sts_build
@@ -21,29 +21,30 @@
 - docker build -t gaiaadm/sts .
 - docker run -d -u jetty -p 9001:8080 gaiaadm/sts
 - Optional: check that server started as needed from outside of docker - curl -v http://localhost:9001/sts/oauth/check_token?token=62ad16cf-ab6c-42fa-af3d-359ecf98cdec
-### Base images used during the process:
+**Base images used during the process**:
 - maven:3.3.3-jdk-8 - build the project (https://registry.hub.docker.com/u/library/maven/)
 - jetty:9.3.0-jre8 - run the server (https://registry.hub.docker.com/u/library/jetty/)
+*The above process is automated with buildAndRun.sh script*
 
 ## Flow:
 - Create Client
     @POST to http://localhost:9001/sts/oauth/client
     Body example:
-    `{
+    {
         "client_id": "restapp",
         "client_secret": "secret",
         "scope": "trust",
         "authorized_grant_types": "client_credentials",
         "authorities": "ROLE_APP",
         "additional_information": "more data"
-    }`
+    }
 -  Obtain token
     @POST to http://localhost:9001/sts/oauth/token?grant_type=client_credentials&client_id=restapp&client_secret=secret
 
 
 - Use token in your client - on example of Java webapp. NOT FINAL VERSION - works but should be cleaned up.
     **web.xml**:
-        `<context-param>
+        <context-param>
             <param-name>contextConfigLocation</param-name>
             <param-value>
                 /WEB-INF/spring-security.xml
@@ -78,11 +79,11 @@
         <filter-mapping>
             <filter-name>springSecurityFilterChain</filter-name>
             <url-pattern>/*</url-pattern>
-        </filter-mapping>`
+        </filter-mapping>
 
     **spring-security.xml** (${authServer} is in default.properties, can be reset via -D parameter):
 
-    `<context:property-placeholder system-properties-mode="OVERRIDE" location="classpath*:default.properties"/>
+    <context:property-placeholder system-properties-mode="OVERRIDE" location="classpath*:default.properties"/>
     <bean class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer">
         <property name="systemPropertiesMode" value="2" />
     </bean>
@@ -110,7 +111,7 @@
         </constructor-arg>
     </bean>
 
-    <oauth:resource-server id="resourceServerFilter" resource-id="test" token-services-ref="remoteTokenServices"/>`
+    <oauth:resource-server id="resourceServerFilter" resource-id="test" token-services-ref="remoteTokenServices"/>
 
 
 ## Other API's exposed:

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Manually run with docker:
   - copy `sts.war`: `docker cp build-cont:/usr/src/app/target/sts.war ./target/`
 - Build STS image with: `docker build -t gaiaadm:sts .`
 - Create and run STS container: `docker run -d -p 9001:8080 gaiaadm/sts`
-- Quick check URL from outside of the container: curl -v http://localhost:9001/sts/oauth/check_token?token=62ad16cf-ab6c-42fa-af3d-359ecf98cdec
+- Quick check URL from outside of the container: `curl -v http://localhost:9001/sts/oauth/check_token?token=62ad16cf-ab6c-42fa-af3d-359ecf98cdec`
 
 
 Flow:

--- a/buildAndRun.sh
+++ b/buildAndRun.sh
@@ -1,0 +1,17 @@
+#/bin/bash
+
+BUILD_IMAGE=sts-build
+BUILD_CONT=build-cont
+
+docker build -t $BUILD_IMAGE -f Dockerfile.build .
+
+if [[ $(docker ps -a | grep $BUILD_CONT | wc -l) > 0 ]] ;
+then docker rm $BUILD_CONT
+fi
+docker create --name $BUILD_CONT $BUILD_IMAGE
+docker cp $BUILD_CONT:/usr/local/gaia/target/sts.war ./target/
+
+docker build -t gaiaadm/sts .
+
+docker run -d -u jetty -p 9001:8080 gaiaadm/sts
+#curl -v http://localhost:9001/sts/oauth/check_token?token=62ad16cf-ab6c-42fa-af3d-359ecf98cdec

--- a/pom.xml
+++ b/pom.xml
@@ -142,7 +142,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.2</version>
+                <version>3.3</version>
                 <configuration>
                     <source>1.8</source>
                     <target>1.8</target>
@@ -151,7 +151,7 @@
             <plugin>
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-maven-plugin</artifactId>
-                <version>9.2.11.v20150529</version>
+                <version>9.3.0.v20150612</version>
                 <configuration>
                     <httpConnector>
                         <port>9001</port>


### PR DESCRIPTION
Use separate Dockerfile/s for build (Maven) and runtime (Jetty).
See [README.md] for detailed instructions. But in general steps are:
1. create Docker image that builds WAR file
2. create container from above image and copy file to local folder
3. create runtime Docker image
4. run it and push it as usual
